### PR TITLE
World transform scaling based on aspect ratio

### DIFF
--- a/RenderSharp/Renderer/Renderer2d/Renderer.cs
+++ b/RenderSharp/Renderer/Renderer2d/Renderer.cs
@@ -24,6 +24,11 @@ namespace RenderSharp.Render2d
         public int Height { get { return Resolution.Y; } set { Resolution.Y = value; } }
 
         /// <summary>
+        /// Aspect ratio of the renderer's target resolution (<see cref="Resolution"/>).
+        /// </summary>
+        public double AspectRatio { get { return (double)Width / Height; } }
+
+        /// <summary>
         /// Target scene for the render.
         /// </summary>
         public Scene Scene { get; set; }
@@ -201,7 +206,7 @@ namespace RenderSharp.Render2d
             {
                 for (int x = 0; x < Width; x++)
                 {
-                    FVec2 worldLoc = Util.Transforms.ScreenToWorld2(Resolution, new Vec2(x, y), scene.Camera.Center, scene.Camera.Zoom, scene.Camera.Rotation);
+                    FVec2 worldLoc = Util.Transforms.ScreenToWorld2(Resolution, new Vec2(x, y), scene.Camera.Center, AspectRatio, scene.Camera.Zoom, scene.Camera.Rotation);
                     Vec2 bgTextureInd = Util.Transforms.WorldToBgTexture2(worldLoc, bgTexture.Size);
                     RGBA outColor = bgTexture[bgTextureInd.X, bgTextureInd.Y];
 

--- a/RenderSharp/Renderer/Util.cs
+++ b/RenderSharp/Renderer/Util.cs
@@ -18,13 +18,16 @@ namespace RenderSharp
             /// <param name="screenSize">Size of the screen.</param>
             /// <param name="screenCoords">Position within the screen.</param>
             /// <param name="cameraCenter">Center of the camera in the world.</param>
+            /// <param name="aspectRatio">Aspect ratio for proper screen scaling.</param>
             /// <param name="cameraZoom">Zoom of the camera.</param>
             /// <param name="cameraRotation">Rotation of the camera.</param>
             /// <returns>The world coordinates corresponding to the screen coordinates.</returns>
-            public static FVec2 ScreenToWorld2(Vec2 screenSize, Vec2 screenCoords, FVec2 cameraCenter, double cameraZoom, double cameraRotation)
+            public static FVec2 ScreenToWorld2(Vec2 screenSize, Vec2 screenCoords, FVec2 cameraCenter, double aspectRatio, double cameraZoom, double cameraRotation)
             {
-                return (new Vec2(screenCoords.X - (screenSize.X / 2),
-                         (screenSize.Y / 2) - screenCoords.Y) / cameraZoom + cameraCenter).Rotate(cameraRotation);
+                FVec2 result = (new FVec2(screenCoords.X - (screenSize.X / 2),
+                         (screenSize.Y / 2) - screenCoords.Y) / screenSize / cameraZoom + cameraCenter).Rotate(cameraRotation);
+                result.X *= aspectRatio;
+                return result;
             }
 
             /// <summary>
@@ -50,7 +53,7 @@ namespace RenderSharp
             /// <returns>The actor coordinates corresponding to the world coordinates, or null if the actor is not intersected.</returns>
             public static FVec2? WorldToActor2(FVec2 worldCoord, FVec2 actorPosition, FVec2 actorSize, double actorRotation)
             {
-                FVec2 result = (actorPosition - worldCoord).Rotate(-actorRotation);
+                FVec2 result = (worldCoord - actorPosition).Rotate(actorRotation);
                 return (result.X < -actorSize.X / 2
                     || result.Y < -actorSize.Y / 2
                     || result.X > actorSize.X / 2

--- a/RenderSharp/Scene/Scene2d/Actor/Line.cs
+++ b/RenderSharp/Scene/Scene2d/Actor/Line.cs
@@ -127,7 +127,7 @@ namespace RenderSharp.Render2d
             FVec2 disp = _end - _start;
             Size.X = disp.Length();
             ((Actor)this).Position = _start + (disp / 2);
-            ((Actor)this).Rotation = Math.Atan2(disp.Y, disp.X);
+            ((Actor)this).Rotation = -Math.Atan2(disp.Y, disp.X);
         }
 
         /// <inheritdoc cref="Actor.Copy"/>

--- a/RenderSharp/Scene/Scene2d/Builders/ActorBuilder.cs
+++ b/RenderSharp/Scene/Scene2d/Builders/ActorBuilder.cs
@@ -67,8 +67,8 @@ namespace RenderSharp.Render2d
         /// <returns>A constructed <see cref="Actor"/>.</returns>
         internal Actor Build()
         {
-            size ??= new FVec2();
-            texture ??= new Texture((Vec2)size, color);
+            size ??= new FVec2(1, 1);
+            texture ??= new Texture(1, 1, color);
             position ??= new FVec2();
             shader ??= ((in FRGBA fragIn, out FRGBA fragOut, Vec2 fragCoord, Vec2 res, double time) => { fragOut = fragIn; });
             return new Actor(size, rotation, position, texture, shader);

--- a/RenderSharp/Scene/Scene2d/Scene/Camera.cs
+++ b/RenderSharp/Scene/Scene2d/Scene/Camera.cs
@@ -13,7 +13,7 @@ namespace RenderSharp.Render2d
         public FVec2 Center { get; set; }
 
         /// <summary>
-        /// Zoom of the camera.
+        /// Zoom of the camera. Represents the world space vertical length of the screen space.
         /// </summary>
         public double Zoom { get; set; }
 

--- a/RenderSharpExample/Program.cs
+++ b/RenderSharpExample/Program.cs
@@ -8,8 +8,8 @@ namespace RenderSharpExample
     {
         static readonly int framerate = 60;
         static readonly int duration = 3;
-        static readonly int resX = 300;
-        static readonly int resY = 300;
+        static readonly int resX = 600;
+        static readonly int resY = 600;
 
         static void Main()
         {
@@ -23,18 +23,19 @@ namespace RenderSharpExample
                     {
                         Actor box = scene.GetActor("Box");
                         Line line = scene.GetLine("Line");
-                        box.Position += new FVec2(0, 50) * dt;
-                        box.Rotation += 3 * dt;
+                        box.Position += new FVec2(0, 0.1) * dt;
                         line.Start = box.Position;
                     }
                 )
                 .WithActor(new ActorBuilder()
-                    .WithSize(new FVec2(100, 100))
+                    .WithSize(new FVec2(0.1, 0.05))
+                    .WithTexture(new Texture(new Vec2(2, 2)))
+                    .WithShader(ExampleShaders.TopLeftDebug)
                     .WithShader(ExampleShaders.Ghostly)
                     , "Box")
                 .WithActor(new LineBuilder()
-                    .WithThickness(10)
-                    .WithEnd(new FVec2(20, 0))
+                    .WithThickness(0.001)
+                    .WithEnd(new FVec2(0.8, 0))
                     .WithColor(new RGB(255, 0, 0))
                     .WithShader(ExampleShaders.Psychedelic)
                     , "Line")


### PR DESCRIPTION
Now, regardless of resolution, the world scale will remain the same, with only wider resolutions showing more on the left and right.

Closes #99 